### PR TITLE
feat: Add public "extractRecordPermissions" method to service

### DIFF
--- a/tests/unit/services/record-permissions/extract-record-permissions.js
+++ b/tests/unit/services/record-permissions/extract-record-permissions.js
@@ -1,0 +1,61 @@
+import attr from 'ember-data/attr'
+import Model from 'ember-data/model'
+import { belongsTo } from 'ember-data/relationships'
+import { test } from 'qunit'
+
+const UserModel = Model.extend({
+  email: attr(),
+  firstName: attr(),
+  lastName: attr(),
+  password: attr(),
+  project: belongsTo()
+})
+
+export default function () {
+  test('it extracts record permissions from a payload', function (assert) {
+    let payload = {
+      id: '1',
+      type: 'users',
+      meta: {
+        permissions: {
+          attributes: {
+            email: 'r',
+            'first-name': 'rw',
+            'last-name': 'rw',
+            password: ''
+          },
+          relationships: {
+            project: 'r'
+          }
+        }
+      }
+    }
+
+    this.owner.register('model:user', UserModel)
+
+    let storeService = this.owner.lookup('service:store')
+    let recordPermissionsService = this.owner.lookup(
+      'service:record-permissions'
+    )
+
+    recordPermissionsService.extractRecordPermissions(
+      storeService.modelFor('user'),
+      payload
+    )
+
+    assert.ok(recordPermissionsService.canRead('email', 'user', '1'))
+    assert.notOk(recordPermissionsService.canWrite('email', 'user', '1'))
+
+    assert.ok(recordPermissionsService.canRead('firstName', 'user', '1'))
+    assert.ok(recordPermissionsService.canWrite('firstName', 'user', '1'))
+
+    assert.ok(recordPermissionsService.canRead('lastName', 'user', '1'))
+    assert.ok(recordPermissionsService.canWrite('lastName', 'user', '1'))
+
+    assert.notOk(recordPermissionsService.canRead('password', 'user', '1'))
+    assert.notOk(recordPermissionsService.canWrite('password', 'user', '1'))
+
+    assert.ok(recordPermissionsService.canRead('project', 'user', '1'))
+    assert.notOk(recordPermissionsService.canWrite('project', 'user', '1'))
+  })
+}

--- a/tests/unit/services/record-permissions/record-permissions-test.js
+++ b/tests/unit/services/record-permissions/record-permissions-test.js
@@ -5,6 +5,7 @@ import runSetModelPermissionsTests from './set-model-permissions'
 import runSetRecordPermissionsTests from './set-record-permissions'
 import runCanReadTests from './can-read'
 import runCanWriteTests from './can-write'
+import runExtractRecordPermissionsTests from './extract-record-permissions'
 
 module('Unit | Service | record-permissions', function (hooks) {
   setupTest(hooks)
@@ -13,4 +14,5 @@ module('Unit | Service | record-permissions', function (hooks) {
   runSetRecordPermissionsTests()
   runCanReadTests()
   runCanWriteTests()
+  runExtractRecordPermissionsTests()
 })


### PR DESCRIPTION
New approach to extracting record permissions from a payload. Usage would be:

```javascript
// serializers/application.js

import { inject as service } from '@ember/service'
import JSONAPISerializer from '@ember-data/serializer/json-api'

export default class ApplicationSerializer extends JSONAPISerializer {
  @service('record-permissions') recordPermissionsService

  normalize (modelClass, payload) {
    this.recordPermissionsService.extractRecordPermissions(modelClass, payload)

    return super.normalize(modelClass, payload)
  }
}
```